### PR TITLE
shotgun を導入した。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,67 @@
+### https://raw.github.com/github/gitignore/2f4cb0220d9f041e0cd3616d7c51aa146195cc6b/Global/osx.gitignore
+
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+### https://raw.github.com/github/gitignore/2f4cb0220d9f041e0cd3616d7c51aa146195cc6b/ruby.gitignore
+
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalisation:
+/.bundle/
+vender/
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 
 gem 'sinatra', '1.4.6'
 gem 'sinatra-reloader', '1.0'
-gem "activerecord"
-gem "mysql2"
+gem 'activerecord'
+gem 'mysql2'
+gem 'shotgun', '~> 0.9.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,8 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
+    shotgun (0.9.1)
+      rack (>= 1.0)
     sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
@@ -51,8 +53,6 @@ PLATFORMS
 DEPENDENCIES
   activerecord
   mysql2
+  shotgun (~> 0.9.1)
   sinatra (= 1.4.6)
   sinatra-reloader (= 1.0)
-
-BUNDLED WITH
-   1.10.3

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 
 ## Set up
 ```
-bundle install
+bundle install --path=vender/bundle
 ```
 
 ## Start Servers
 ```
-ruby myapp.rb
+bundle exec shotgun
 ```
 
 ## See Also

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,4 @@
+root  = ::File.dirname(__FILE__)
+require ::File.join(root, 'myapp')
+
+run Server

--- a/init.rb
+++ b/init.rb
@@ -1,0 +1,2 @@
+# FIXME: ディレクトリ以下を全部ロードできるようにしたい。
+require_relative 'models/post.rb'

--- a/models/post.rb
+++ b/models/post.rb
@@ -1,0 +1,2 @@
+class Post < ActiveRecord::Base
+end

--- a/myapp.rb
+++ b/myapp.rb
@@ -4,26 +4,27 @@ require 'sinatra/reloader'
 require 'active_record'
 require 'mysql2'
 
-# DB設定ファイルの読み込み
+require_relative 'init'
+
+# FIXME: DBの接続情報は別に切り出したい。
 ActiveRecord::Base.configurations = YAML.load_file('database.yml')
 ActiveRecord::Base.establish_connection(:development)
 
-class Post < ActiveRecord::Base
-end
+class Server < Sinatra::Base
+  get '/' do
+    @posts = Post.order('created_at DESC').limit(10)
+    erb :index
+  end
 
-get '/' do
-  @posts = Post.order('created_at DESC').limit(10)
-  erb :index
-end
+  post '/post' do
+    user_name = params[:user_name]
+    body      = params[:body]
 
-post '/post' do
-  user_name = params[:user_name]
-  body      = params[:body]
+    post = Post.new
+    post.user_name = user_name
+    post.body      = body
+    post.save!
 
-  post = Post.new
-  post.user_name = user_name
-  post.body      = body
-  post.save!
-
-  redirect '/'
+    redirect '/'
+  end
 end


### PR DESCRIPTION
@maroncoly 
勢いでPR書いてみました。
## 背景

sinatra アプリを立ち上げるときに shotgun という gem を使えば、
サーバ設定を変えても自動でリロードしてくれるとのことだったので、
思い立って導入してみました。
README にある shotgun コマンドで立ち上げると、 http://127.0.0.1:9393/ でアクセスできます。

> ### Shotgun
> 
> This is an automatic reloading version of the rackup command that's shipped with Rack.
> https://github.com/rtomayko/shotgun
## やったこと
- .gitignore の追加
  - `gibo osx ruby >> .gitignore`
- shotgun が読み込む config.ru の追加
- README の編集
## 補足
- いくつか FIXME 書いてますが、あまりイケてない感じになっているところがあるのでどうにかしたいです。
