### PR TITLE
README 編集

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,3 +56,6 @@ DEPENDENCIES
   shotgun (~> 0.9.1)
   sinatra (= 1.4.6)
   sinatra-reloader (= 1.0)
+
+BUNDLED WITH
+   1.10.3

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ bundle install --path=vender/bundle
 
 ## Start Servers
 ```
+mysql.server start
 bundle exec shotgun
 ```
 


### PR DESCRIPTION
## 背景

READMEにmysqlの立ち上げコマンドが不足していた
## やったこと

READMEに立ち上げコマンドを追記
## 補足

とくになし
